### PR TITLE
fix: string to runes fix emoji length

### DIFF
--- a/lib/v3/typewriter_value.dart
+++ b/lib/v3/typewriter_value.dart
@@ -31,8 +31,7 @@ class TypeWriterValue {
 
   /// Total length of [data].
   int get length {
-    final result = data.fold<int>(
-        0, (p, n) => p + String.fromCharCodes(n.runes.toList()).length);
+    final result = data.fold<int>(0, (p, n) => p + n.runes.toList().length);
     assert(result > 0, 'Length of text data must be greater than 0');
     return result;
   }
@@ -51,11 +50,11 @@ class TypeWriterValue {
 
     for (String item in data) {
       var index = <int>[];
-      for (int i = 0; i < item.length; i++) {
+      for (int i = 0; i < item.runes.length; i++) {
         index.add(current + i);
       }
       indexes.add(index);
-      current = current + item.length;
+      current = current + item.runes.length;
     }
 
     return indexes;
@@ -68,7 +67,7 @@ class TypeWriterValue {
         input: data.join(),
         start:
             (index < 0 ? _indexes.last.first : _indexes[index].first) % length,
-        end: this.index);
+        end: this.index + 1);
   }
 
   String runeSubstring(

--- a/lib/v3/typewriter_value.dart
+++ b/lib/v3/typewriter_value.dart
@@ -31,7 +31,8 @@ class TypeWriterValue {
 
   /// Total length of [data].
   int get length {
-    final result = data.fold<int>(0, (p, n) => p + n.length);
+    final result = data.fold<int>(
+        0, (p, n) => p + String.fromCharCodes(n.runes.toList()).length);
     assert(result > 0, 'Length of text data must be greater than 0');
     return result;
   }
@@ -63,9 +64,16 @@ class TypeWriterValue {
   /// Current displayed text based on given [index].
   String get text {
     var index = _indexes.indexWhere((e) => e.contains(this.index));
-    return data.join().substring(
-        (index < 0 ? _indexes.last.first : _indexes[index].first) % length,
-        this.index + 1);
+    return runeSubstring(
+        input: data.join(),
+        start:
+            (index < 0 ? _indexes.last.first : _indexes[index].first) % length,
+        end: this.index);
+  }
+
+  String runeSubstring(
+      {required String input, required int start, required int end}) {
+    return String.fromCharCodes(input.runes.toList().sublist(start, end));
   }
 
   @override

--- a/test/typewriter_value_test.dart
+++ b/test/typewriter_value_test.dart
@@ -4,23 +4,23 @@ import 'package:typewritertext/typewritertext.dart';
 void main() {
   group('TypeWriterValue', () {
     final value = TypeWriterValue(
-      ['the', 'hash', 'slinging', 'slasher'],
-      index: 2,
+      ['the👑', 'hash', 'slinging', 'slasher'],
+      index: 3,
     );
 
     test('text', () {
-      expect(value.text, equals('the'));
-      value.index = 21;
+      expect(value.text, equals('the👑'));
+      value.index = 22;
       expect(value.text, equals('slasher'));
-      value.index = 24;
+      value.index = 25;
       expect(value.text, equals('the'));
       expect(
           value.toString(),
           equals(
-              'TypeWriterValue{data: [the, hash, slinging, slasher], text: the, index: 2}'));
+              'TypeWriterValue{data: [the👑, hash, slinging, slasher], text: the, index: 2}'));
     });
     test('length', () {
-      expect(value.length, equals(22));
+      expect(value.length, equals(23));
       value.data = ['dummy'];
       expect(value.length, equals(5));
     });


### PR DESCRIPTION

<img width="145" alt="image" src="https://github.com/Nialixus/typewritertext/assets/18257790/9cd678c9-4572-48e3-aa2f-c78af79971fd">

if `TextWriter.text` contain emoji, `String.substring` method will cause the error below, use `String.runes.sublist` instead.
```
Invalid argument(s): string is not well-formed UTF-16
```